### PR TITLE
Camera calibration + JSON Parsing script added

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,5 @@
+For the calibration script:
+
+use this chessboard for pictures and printing:
+
+https://github.com/opencv/opencv/blob/master/doc/pattern.png

--- a/python/camera_calibrate.py
+++ b/python/camera_calibrate.py
@@ -1,0 +1,39 @@
+import numpy as np
+import cv2
+import glob
+
+chessboard_size = (9, 6)  # 9x6 chessboard
+square_size = 1.0         
+objp = np.zeros((chessboard_size[0]*chessboard_size[1], 3), np.float32)
+objp[:, :2] = np.mgrid[0:chessboard_size[0], 0:chessboard_size[1]].T.reshape(-1, 2)
+objp *= square_size
+
+objpoints = []  
+imgpoints = []  
+
+images = glob.glob('calibration_images/*.jpg')  # put your images here
+
+for fname in images:
+    img = cv2.imread(fname)
+    gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+
+    ret, corners = cv2.findChessboardCorners(gray, chessboard_size, None)
+
+    if ret:
+        objpoints.append(objp)
+        corners2 = cv2.cornerSubPix(gray, corners, (11,11), (-1,-1),
+                                    criteria=(cv2.TERM_CRITERIA_EPS + cv2.TERM_CRITERIA_MAX_ITER, 30, 0.001))
+        imgpoints.append(corners2)
+
+        cv2.drawChessboardCorners(img, chessboard_size, corners2, ret)
+        cv2.imshow('Corners', img)
+        cv2.waitKey(200)
+
+cv2.destroyAllWindows()
+
+ret, K, dist, rvecs, tvecs = cv2.calibrateCamera(objpoints, imgpoints, gray.shape[::-1], None, None)
+
+print("Camera matrix (K):\n", K)
+print("Distortion coefficients:\n", dist)
+
+np.savez("calibration_data.npz", K=K, dist=dist, rvecs=rvecs, tvecs=tvecs)

--- a/python/parse_JSON.py
+++ b/python/parse_JSON.py
@@ -1,0 +1,105 @@
+import json
+import pandas as pd
+import numpy as np
+
+def load_log(file_path):
+    """
+    Loads the JSON lines from the given file and returns a Pandas DataFrame
+    with columns: Image_ID, Latitude, Longitude, Altitude, Roll, Pitch, Yaw, Timestamp.
+    """
+    data_list = []
+    with open(file_path, "r") as file:
+        for line in file:
+            json_obj = json.loads(line.strip())
+            data = json_obj["data"]
+            
+            data_list.append({
+                "Image_ID": data.get("Img"),
+                "Latitude": data.get("Lat"),
+                "Longitude": data.get("Lng"),
+                "Altitude": data.get("Alt"),
+                "Roll": data.get("R"),    # degrees (assumed)
+                "Pitch": data.get("P"),  # degrees (assumed)
+                "Yaw": data.get("Y"),    # degrees (assumed)
+                "Timestamp": data.get("TimeUS")
+            })
+    return pd.DataFrame(data_list)
+
+def compute_3D_from_pixel(lat, lng, alt, roll_deg, pitch_deg, yaw_deg,
+                         pixel_x, pixel_y, focal_length):
+    # Convert angles to radians (assuming its in degrees)
+    roll = np.radians(roll_deg)
+    pitch = np.radians(pitch_deg)
+    yaw = np.radians(yaw_deg)
+
+    # Intrinsic Camera Matrix K
+    K = np.array([
+        [focal_length,        0,   0],
+        [       0,     focal_length, 0],
+        [       0,             0,   1]
+    ], dtype=float)
+
+    # Rotation matrices Rx, Ry, Rz
+    Rx = np.array([
+        [1,           0,           0],
+        [0,  np.cos(roll), -np.sin(roll)],
+        [0,  np.sin(roll),  np.cos(roll)]
+    ], dtype=float)
+    
+    Ry = np.array([
+        [ np.cos(pitch), 0, np.sin(pitch)],
+        [             0, 1,             0],
+        [-np.sin(pitch), 0, np.cos(pitch)]
+    ], dtype=float)
+    
+    Rz = np.array([
+        [ np.cos(yaw), -np.sin(yaw), 0],
+        [ np.sin(yaw),  np.cos(yaw), 0],
+        [          0,           0,   1]
+    ], dtype=float)
+    
+    R_cam2world = Rz @ Ry @ Rx
+
+    pixel_hom = np.array([pixel_x, pixel_y, 1], dtype=float)
+
+    K_inv = np.linalg.inv(K)
+    dir_cam = K_inv @ pixel_hom  # direction in camera coords
+
+    dir_world = R_cam2world @ dir_cam
+
+    if abs(dir_world[2]) < 1e-12:
+        return np.array([np.nan, np.nan, np.nan])
+
+    scale = alt / dir_world[2]
+
+    camera_center = np.array([lat, lng, alt], dtype=float)
+
+    point_world = camera_center + scale * dir_world
+
+    return point_world
+
+# ------------------------------------------------------------------------
+# Example usage:
+df = load_log("parse_text/trig.txt")
+print("Parsed DataFrame:\n", df, "\n")
+
+focal_length = 5000  # example focal length in pixels from geogebra
+
+example = df.iloc[0]
+print("Example row:\n", example, "\n")
+
+# Suppose we want to see where the ray from pixel = (2736, 1824) ends up,
+# forcing Z = Altitude in our simplistic approach:
+xyz_world = compute_3D_from_pixel(
+    lat=example["Latitude"],
+    lng=example["Longitude"],
+    alt=example["Altitude"],
+    roll_deg=example["Roll"],
+    pitch_deg=example["Pitch"],
+    yaw_deg=example["Yaw"],
+    pixel_x=2736,
+    pixel_y=1824,
+    focal_length=focal_length
+)
+
+print("Computed 3D world point from pixel (2736, 1824):", xyz_world)

--- a/python/parse_text/trig.txt
+++ b/python/parse_text/trig.txt
@@ -1,0 +1,3 @@
+{"meta": {"type": "TRIG", "timestamp": 188.389187}, "data": {"TimeUS": 188389187, "I": 0, "Img": 1, "GPSTime": 0, "GPSWeek": 0, "Lat": 0.0, "Lng": 0.0, "Alt": 0.94, "RelAlt": 0.94, "GPSAlt": 0.0, "R": -1.14, "P": -0.17, "Y": 320.33}}
+{"meta": {"type": "TRIG", "timestamp": 201.809215}, "data": {"TimeUS": 201809215, "I": 0, "Img": 2, "GPSTime": 0, "GPSWeek": 0, "Lat": 0.0, "Lng": 0.0, "Alt": 0.92, "RelAlt": 0.92, "GPSAlt": 0.0, "R": -1.14, "P": -0.16, "Y": 320.23}}
+{"meta": {"type": "TRIG", "timestamp": 219.32915799999998}, "data": {"TimeUS": 219329158, "I": 0, "Img": 3, "GPSTime": 0, "GPSWeek": 0, "Lat": 0.0, "Lng": 0.0, "Alt": 1.3, "RelAlt": 1.3, "GPSAlt": 0.0, "R": -1.11, "P": -0.14, "Y": 320.41}}


### PR DESCRIPTION
# Description

Added camera calibration and pixel-to-3D world point conversion functionality.

- `camera_calibrate.py` performs calibration using chessboard images and saves camera intrinsics.
- `parse_JSON.py` parses trigger logs and computes corresponding 3D world coordinates from pixel locations.
- Added a sample calibration image, chessboard link, and test data in `parse_text/trig.txt`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Manually ran both scripts with sample data and verified output.
- Confirmed calibration and 3D point computation print expected results.

## Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [x] I have made corresponding changes to the documentation  
- [x] My changes generate no new warnings  
